### PR TITLE
[ADD] features --nsfilters --auto_generate and --subdir

### DIFF
--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -25,51 +25,26 @@ def fetch_records(domain):
 
 def fetch_domains_list(organization_id):
     if organization_id is not None:
-        fh_url = f"https://api.gandi.net/v5/domain/domains?per_page=1&sort_by=fqdn&sharing_id={organization_id}"
+        payload = {'per_page': 1, 'sort_by': 'fqdn', 'sharing_id': organization_id}
     else:
-        fh_url = f"https://api.gandi.net/v5/domain/domains?per_page=1&sort_by=fqdn"
+        payload = {'per_page': 1, 'sort_by': 'fqdn'}
     ## Get total count of domain & fetch all in one page
     fake_head = requests.get(
-        fh_url,
-        headers={"authorization": f'Apikey {os.getenv("GANDI_KEY")}'},
+        'https://api.gandi.net/v5/domain/domains',
+        headers={"authorization": f'Apikey {os.getenv("GANDI_KEY")}'}, params=payload
     )
     fake_head.raise_for_status()
     total_count = fake_head.headers["total-count"]
     if organization_id is not None:
-        get_url = f"https://api.gandi.net/v5/domain/domains?per_page={total_count}&sort_by=fqdn&sharing_id={organization_id}"
+        payload = {'per_page': total_count, 'sort_by': 'fqdn', 'sharing_id': organization_id}
     else:
-        get_url = f"https://api.gandi.net/v5/domain/domains?per_page={total_count}&sort_by=fqdn"
+        payload = {'per_page': total_count, 'sort_by': 'fqdn'}
     r = requests.get(
-        get_url,
-        headers={"authorization": f'Apikey {os.getenv("GANDI_KEY")}'},
+        'https://api.gandi.net/v5/domain/domains',
+        headers={"authorization": f'Apikey {os.getenv("GANDI_KEY")}'}, params=payload
     )
     r.raise_for_status()
     return r.json()
-
-
-def print_domains_list(domains, list_domains_details, nsfilters):
-    if list_domains_details is True:
-        for domain in domains:
-            if domain['nameserver']['current'] in nsfilters:
-                print(domain)
-    else:
-        for domain in domains:
-            if domain['nameserver']['current'] in nsfilters:
-                print(domain["fqdn_unicode"])
-
-
-def fetch_organizations_list():
-    r = requests.get(
-        "https://api.gandi.net/v5/organization/organizations",
-        headers={"authorization": f'Apikey {os.getenv("GANDI_KEY")}'},
-    )
-    r.raise_for_status()
-    return r.json()
-
-
-def print_organizations_list(organizations):
-    for organization in organizations:
-        print(organization)
 
 
 def parse_content(content):
@@ -157,40 +132,24 @@ def generate_tf(domain, entries, subdir):
 
 @click.command(no_args_is_help=True)
 @click.option("--version", help="Display version information", is_flag=True)
-@click.option("--organization_id", help="Gandi organization ID (passing an organization ID will limit query on domain own by organization)", default=None)
-@click.option("--list_domains", help="Fetch and display fqdn_unicode", is_flag=True)
-@click.option("--list_domains_details", help="Fetch and display all domain details", is_flag=True)
-@click.option("--list_organizations", help="Fetch and display all organizations details", is_flag=True)
-@click.option('--nsfilters', help="Filter domaine based on their current nameserver 'abc','livedns' or 'other'. You can add multiple filter Example: gandi2tf --list_domains --nsfilters abc --nsfilters livedns)", multiple=True, default=[
-'abc','livedns','other'])
-@click.option("--auto_generate", help="Auto-generate tf resource based on domain from gandi instead of STDIN/USERINPUT (option can be used with --organization_id, --subdir and multiple --nsfilters)", is_flag=True)
+@click.option("--organization_id", help="To list domains only owned by this organization id", default=None)
+@click.option('--nsfilters', type=click.Choice(['abc','livedns','other'], case_sensitive=True), help="Filter domaine based on their current nameserver 'abc','livedns' or 'other'. You can add multiple filter Example: gandi2tf --list_domains --nsfilters abc --nsfilters livedns)", multiple=True, default=[
+'abc',' ','other'])
+@click.option("--auto-generate", help="Auto-generate tf resources based on domain from gandi instead of STDIN/USERINPUT (option can be used with --organization_id, --subdir and multiple --nsfilters)", is_flag=True)
 @click.option("--subdir", help="Create a sub-directory to store generated domain tf and tf import command", is_flag=True)
 @click.argument("domains", nargs=-1)
-def generate(domains, version, organization_id, list_domains, list_domains_details, list_organizations, nsfilters, auto_generate, subdir):
+def generate(domains, version, organization_id, nsfilters, auto_generate, subdir):
     """
     Command to read Gandi.net live DNS records and generate
     corresponding TF gandi_livedns_record resources.
 
     Warning: nameserver type 'other' and 'abc' can't be managed via terraform (for abc domain you can transfer them to livedns on gandi webinterface)
     """
-    for filter in nsfilters:
-        if filter not in ['abc','livedns','other']:
-            print(f"nsfilters error available filter: 'abc', 'livedns' or 'other' you submitted {nsfilters}")
-            return
     if version:
         import importlib.metadata
 
         _version = importlib.metadata.version("gandi-2-terraform")
         click.echo(f"Version {_version}")
-        return
-    if list_domains:
-        print_domains_list(fetch_domains_list(organization_id), list_domains_details, nsfilters)
-        return
-    if list_domains_details:
-        print_domains_list(fetch_domains_list(organization_id), list_domains_details, nsfilters)
-        return
-    if list_organizations:
-        print_organizations_list(fetch_organizations_list())
         return
     if auto_generate:
         domains = []
@@ -198,13 +157,13 @@ def generate(domains, version, organization_id, list_domains, list_domains_detai
         for domain in fetch_domains:
             if domain['nameserver']['current'] in nsfilters:
                 if "other" in domain['nameserver']['current']:
-                    print("Your are trying to auto_generate a tf from a domain not managed by Gandi check tour nsfilters")
+                    click.echo("Your are trying to auto_generate a tf from a domain not managed by Gandi check your nsfilters")
                     return
                 else:
                     domains.append(domain["fqdn_unicode"])
         if domains == []:
-            print("--auto_generate was used but did not return any domain check your cmd line or use less restrictive nsfilters")
-        
+            click.echo("--auto_generate was used but did not return any domain check your cmd line or use less restrictive nsfilters")
+
     commands = []
     for domain in domains:
         content = fetch_records(domain)

--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -133,8 +133,7 @@ def generate_tf(domain, entries, subdir):
 @click.command(no_args_is_help=True)
 @click.option("--version", help="Display version information", is_flag=True)
 @click.option("--organization_id", help="To list domains only owned by this organization id", default=None)
-@click.option('--nsfilters', type=click.Choice(['abc','livedns','other'], case_sensitive=True), help="Filter domaine based on their current nameserver 'abc','livedns' or 'other'. You can add multiple filter Example: gandi2tf --list_domains --nsfilters abc --nsfilters livedns)", multiple=True, default=[
-'abc',' ','other'])
+@click.option('--nsfilters', type=click.Choice(['abc','livedns','other'], case_sensitive=True), help="Filter domaine based on their current nameserver 'abc','livedns' or 'other'. You can add multiple filter Example: gandi2tf --list_domains --nsfilters abc --nsfilters livedns)", multiple=True, default=['abc','livedns','other'])
 @click.option("--auto-generate", help="Auto-generate tf resources based on domain from gandi instead of STDIN/USERINPUT (option can be used with --organization_id, --subdir and multiple --nsfilters)", is_flag=True)
 @click.option("--subdir", help="Create a sub-directory to store generated domain tf and tf import command", is_flag=True)
 @click.argument("domains", nargs=-1)

--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -12,9 +12,6 @@ class Record:
 
 
 def fetch_records(domain):
-    # When domain contain a - api call return a 404 encoding it work
-    domain = domain.replace("-", "%2D")
-    print(domain)
     r = requests.get(
         f"https://dns.api.gandi.net/api/v5/domains/{domain}/records",
         headers={

--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -109,6 +109,12 @@ def generate_tf(domain, entries, subdir):
     else:
         filename = f"{domain}.tf"
     tf_name = domain.replace(".", "_")
+    ## TF resource can't start with number should be either _ or a letter so domain like 1984.com will generate error with terraform
+    try:
+        c0 = int(tf_name[0])
+        tf_name = "_" + tf_name
+    except ValueError as e:
+        pass
     commands = []
     with click.open_file(filename, "w") as f:
         f.write("locals {\n")

--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -152,18 +152,20 @@ def generate_tf(domain, entries, subdir):
 @click.command(no_args_is_help=True)
 @click.option("--version", help="Display version information", is_flag=True)
 @click.option("--organization_id", help="Gandi organization ID (passing an organization ID will limit query on domain own by organization)", default=None)
-@click.option("--list_domains", help="Fetch and display fqdn_unicodde", is_flag=True)
+@click.option("--list_domains", help="Fetch and display fqdn_unicode", is_flag=True)
 @click.option("--list_domains_details", help="Fetch and display all domain details", is_flag=True)
 @click.option("--list_organizations", help="Fetch and display all organizations details", is_flag=True)
 @click.option('--nsfilters', help="Filter domaine based on their current nameserver 'abc','livedns' or 'other'. You can add multiple filter Example: gandi2tf --list_domains --nsfilters abc --nsfilters livedns)", multiple=True, default=[
 'abc','livedns','other'])
-@click.option("--auto_generate", help="Auto-generate tf resource based on domain from gandi instead of STDIN/USERINPUT (option can be used with --organization_id and multiple --nsfilters)", is_flag=True)
+@click.option("--auto_generate", help="Auto-generate tf resource based on domain from gandi instead of STDIN/USERINPUT (option can be used with --organization_id, --subdir and multiple --nsfilters)", is_flag=True)
 @click.option("--subdir", help="Create a sub-directory to store generated domain tf and tf import command", is_flag=True)
 @click.argument("domains", nargs=-1)
 def generate(domains, version, organization_id, list_domains, list_domains_details, list_organizations, nsfilters, auto_generate, subdir):
     """
     Command to read Gandi.net live DNS records and generate
     corresponding TF gandi_livedns_record resources.
+
+    Warning: nameserver type 'other' and 'abc' can't be managed via terraform (for abc domain you can transfert them to livedns on gandi webinterface)
     """
     for filter in nsfilters:
         if filter not in ['abc','livedns','other']:

--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -165,7 +165,7 @@ def generate(domains, version, organization_id, list_domains, list_domains_detai
     Command to read Gandi.net live DNS records and generate
     corresponding TF gandi_livedns_record resources.
 
-    Warning: nameserver type 'other' and 'abc' can't be managed via terraform (for abc domain you can transfert them to livedns on gandi webinterface)
+    Warning: nameserver type 'other' and 'abc' can't be managed via terraform (for abc domain you can transfer them to livedns on gandi webinterface)
     """
     for filter in nsfilters:
         if filter not in ['abc','livedns','other']:


### PR DESCRIPTION
Hello,

[ADD] features & support for organization + nameserver filter and subdir organization.
--organization_id TEXT  Gandi organization ID (passing an organization ID will limit query on domain own by organization)

--list_domains          Fetch and display fqdn_unicodde
--list_domains_details  Fetch and display all domain details
--list_organizations    Fetch and display all organizations details

--nsfilters TEXT        Filter domaine based on their current nameserver 'abc','livedns' or 'other'. You can add multiple filter Example: gandi2tf --list_domains --nsfilters abc --nsfilters livedns)

--auto_generate         Auto-generate tf resource based on domain from gandi instead of STDIN/USERINPUT (option can be used with --organization_id and multiple --nsfilters)

--subdir Create a sub-directory to store generated domain tf and tf import command
