### PR TITLE
feat: use either Apikey or Bearer authorization header

### DIFF
--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -72,8 +72,8 @@ def get_authentication_header():
     Returns the correct authentication header based on the GANDI_KEY environment variable.
     """
     key = os.getenv("GANDI_KEY", "")
-    header = "Apikey" if len(key) <= 25 else "Bearer"
-    return {"Authentication": f"{header} {key}"}
+    header = "Apikey" if len(key) < 25 else "Bearer"
+    return {"Authorization": f"{header} {key}"}
 
 
 def parse_content(content):

--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -25,10 +25,7 @@ def fetch_records(domain):
     """
     req = requests.get(
         f"https://dns.api.gandi.net/api/v5/domains/{domain}/records",
-        headers={
-            "Accept": "text/plain",
-        }
-        | get_authentication_header(),
+        headers={**{"Accept": "text/plain"}, **get_authentication_header()},
         timeout=5,
     )
     req.raise_for_status()

--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -27,7 +27,8 @@ def fetch_records(domain):
         f"https://dns.api.gandi.net/api/v5/domains/{domain}/records",
         headers={
             "Accept": "text/plain",
-        } | get_authentication_header(),
+        }
+        | get_authentication_header(),
         timeout=5,
     )
     req.raise_for_status()

--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -26,9 +26,8 @@ def fetch_records(domain):
     req = requests.get(
         f"https://dns.api.gandi.net/api/v5/domains/{domain}/records",
         headers={
-            "X-Api-Key": os.getenv("GANDI_KEY"),
             "Accept": "text/plain",
-        },
+        } | get_authentication_header(),
         timeout=5,
     )
     req.raise_for_status()
@@ -47,7 +46,7 @@ def fetch_domains_list(organization_id):
     # Get total count of domain to fetch them all in one request
     fake_head = requests.get(
         "https://api.gandi.net/v5/domain/domains",
-        headers={"authorization": f'Apikey {os.getenv("GANDI_KEY")}'},
+        headers=get_authentication_header(),
         params=payload,
         timeout=5,
     )
@@ -62,12 +61,18 @@ def fetch_domains_list(organization_id):
 
     req = requests.get(
         "https://api.gandi.net/v5/domain/domains",
-        headers={"authorization": f'Apikey {os.getenv("GANDI_KEY")}'},
+        headers=get_authentication_header(),
         params=payload,
         timeout=5,
     )
     req.raise_for_status()
     return req.json()
+
+
+def get_authentication_header():
+    key = os.getenv("GANDI_KEY", "")
+    header = "Apikey" if len(key) <= 25 else "Bearer"
+    return {"Authentication": f"{header} {key}"}
 
 
 def parse_content(content):

--- a/gandi_tf/main.py
+++ b/gandi_tf/main.py
@@ -71,6 +71,9 @@ def fetch_domains_list(organization_id):
 
 
 def get_authentication_header():
+    """
+    Returns the correct authentication header based on the GANDI_KEY environment variable.
+    """
     key = os.getenv("GANDI_KEY", "")
     header = "Apikey" if len(key) <= 25 else "Bearer"
     return {"Authentication": f"{header} {key}"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ non_interactive = true
 install_types = true
 
 [tool.ruff]
-select = ["E", "F"]
+lint.select = ["E", "F"]
 line-length = 119
 target-version = "py38"
 


### PR DESCRIPTION
## What

Allow for authentication through either the legacy API key, or the Bearer PAT. Both should be provided still under the same environment key `GANDI_KEY`.

Looking at the existing values for both, the PAT is longer and therefore I suppose the type of token can be detected based on its length.

Closes #73 